### PR TITLE
Fix the frame index

### DIFF
--- a/src/rl-inference-engine/dataset/custom_feat_extractor.py
+++ b/src/rl-inference-engine/dataset/custom_feat_extractor.py
@@ -113,7 +113,7 @@ class CustomFeatExtractor():
                 image_path = os.path.join(folder, (str(i).zfill(10)+'.png'))
             else:
                 image_path = os.path.join(
-                    folder, 'frame{:06d}.jpg'.format(i))
+                    folder, 'frame{:06d}.jpg'.format(i+1))
 
             image = Image.open(image_path).convert('RGB')
 


### PR DESCRIPTION
As specified in the README, the filename starts from `frame000001.jpg`.